### PR TITLE
Quick fix for error SplitOff with count <= 0

### DIFF
--- a/NR_AutoMachineTool/Source/Building_AutoMachineTool.cs
+++ b/NR_AutoMachineTool/Source/Building_AutoMachineTool.cs
@@ -386,8 +386,15 @@ namespace NR_AutoMachineTool
             var result = WorkableBill(consumable).Select(tuple =>
             {
                 this.bill = tuple.Value1;
-//                tuple.Value2.Select(v => v.thing).SelectMany(t => Option(t as Corpse)).ForEach(c => c.Strip());
-                this.ingredients = tuple.Value2.Select(t => t.thing.SplitOff(t.count)).ToList();
+                //tuple.Value2.Select(v => v.thing).SelectMany(t => Option(t as Corpse)).ForEach(c => c.Strip());
+                try
+                {
+                    this.ingredients = tuple.Value2.Select(t => t.thing.SplitOff(t.count)).ToList();
+                }
+                catch
+                {
+                    return new { Result = false, WorkAmount = 0f };
+                }
                 this.dominant = this.DominantIngredient(this.ingredients);
                 if (this.bill.recipe.UsesUnfinishedThing)
                 {


### PR DESCRIPTION
System.ArgumentException: SplitOff with count <= 0
Parameter name: count
  at Verse.Thing.SplitOff (System.Int32 count) [0x00004] in <7927e938de4c4089b4add4215e58d5b1>:0
  at Verse.ThingWithComps.SplitOff (System.Int32 count) [0x00000] in <7927e938de4c4089b4add4215e58d5b1>:0
  at NR_AutoMachineTool.Building_AutoMachineTool+<>c.<TryStartWorking>b__47_2 (NR_AutoMachineTool.Building_AutoMachineTool+ThingAmount t) [0x00000] in <74570a4a7a2e49b3b78d778391fd1443>:0
  at System.Linq.Enumerable+SelectListIterator`2[TSource,TResult].ToList () [0x0002a] in <351e49e2a5bf4fd6beabb458ce2255f3>:0
  at System.Linq.Enumerable.ToList[TSource] (System.Collections.Generic.IEnumerable`1[T] source) [0x0001f] in <351e49e2a5bf4fd6beabb458ce2255f3>:0
  at NR_AutoMachineTool.Building_AutoMachineTool.<TryStartWorking>b__47_1 (NR_AutoMachineTool.Utilities.Tuple`2[T1,T2] tuple) [0x00037] in <74570a4a7a2e49b3b78d778391fd1443>:0
  at NR_AutoMachineTool.Utilities.Option`1[T].Select[TO] (System.Func`2[T,TResult] func) [0x0000e] in <74570a4a7a2e49b3b78d778391fd1443>:0
  at NR_AutoMachineTool.Building_AutoMachineTool.TryStartWorking (NR_AutoMachineTool.Building_AutoMachineTool& target, System.Single& workAmount) [0x0004b] in <74570a4a7a2e49b3b78d778391fd1443>:0
  at NR_AutoMachineTool.Building_Base`1[T].Ready () [0x0003a] in <74570a4a7a2e49b3b78d778391fd1443>:0
  at NR_AutoMachineTool.Building_BaseRange`1[T].Ready () [0x00000] in <74570a4a7a2e49b3b78d778391fd1443>:0
  at NR_AutoMachineTool.Building_AutoMachineTool.Ready () [0x00006] in <74570a4a7a2e49b3b78d778391fd1443>:0
  at NR_AutoMachineTool.MapTickManager.Exec (System.Action act) [0x00000] in <74570a4a7a2e49b3b78d778391fd1443>:0